### PR TITLE
Fix clock/gclock pointer

### DIFF
--- a/lib/dbms_buffers/clock.rb
+++ b/lib/dbms_buffers/clock.rb
@@ -67,6 +67,7 @@ module DbmsBuffers
       if entry.clock_value.zero?
         entry.value = value
         entry.clock_value = 1
+        advance_pointer
         return true
       end
 

--- a/lib/dbms_buffers/gclock.rb
+++ b/lib/dbms_buffers/gclock.rb
@@ -66,6 +66,7 @@ module DbmsBuffers
       if entry.clock_value.zero?
         entry.value = value
         entry.clock_value = 1
+        advance_pointer
         return true
       end
 

--- a/spec/clock_spec.rb
+++ b/spec/clock_spec.rb
@@ -5,11 +5,14 @@ RSpec.describe DbmsBuffers::ClockBuffer do
     buffer = DbmsBuffers::ClockBuffer.new(3)
     expect(buffer.size).to be 3
     expect(buffer.used).to be 0
+    expect(buffer.pointer).to be 0
   end
 
   it 'contains just referenced entry' do
     buffer = DbmsBuffers::ClockBuffer.new(2)
+    expect(buffer.pointer).to be 0
     buffer.access('a')
+    expect(buffer.pointer).to be 1
     expect(buffer.used).to be 1
     expect(buffer.contains?('a')).to be true
     expect(buffer.clock_value_of('a')).to be 1
@@ -17,8 +20,11 @@ RSpec.describe DbmsBuffers::ClockBuffer do
 
   it 'does not contain same entry twice' do
     buffer = DbmsBuffers::ClockBuffer.new(2)
+    expect(buffer.pointer).to be 0
     buffer.access('a')
+    expect(buffer.pointer).to be 1
     buffer.access('a')
+    expect(buffer.pointer).to be 1
     expect(buffer.used).to be 1
     expect(buffer.contains?('a')).to be true
     expect(buffer.clock_value_of('a')).to be 1
@@ -26,8 +32,11 @@ RSpec.describe DbmsBuffers::ClockBuffer do
 
   it 'can hold multiple entries' do
     buffer = DbmsBuffers::ClockBuffer.new(2)
+    expect(buffer.pointer).to be 0
     buffer.access('a')
+    expect(buffer.pointer).to be 1
     buffer.access('b')
+    expect(buffer.pointer).to be 0
     expect(buffer.used).to be 2
     expect(buffer.contains?('a')).to be true
     expect(buffer.clock_value_of('a')).to be 1
@@ -37,9 +46,13 @@ RSpec.describe DbmsBuffers::ClockBuffer do
 
   it 'gives second chance' do
     buffer = DbmsBuffers::ClockBuffer.new(2)
+    expect(buffer.pointer).to be 0
     buffer.access :a
+    expect(buffer.pointer).to be 1
     buffer.access :b
+    expect(buffer.pointer).to be 0
     buffer.access :c
+    expect(buffer.pointer).to be 1
 
     expect(buffer.contains?(:a) ^ buffer.contains?(:b)).to be true
 

--- a/spec/gclock_spec.rb
+++ b/spec/gclock_spec.rb
@@ -5,11 +5,14 @@ RSpec.describe DbmsBuffers::GClockBuffer do
     buffer = DbmsBuffers::GClockBuffer.new(3)
     expect(buffer.size).to be 3
     expect(buffer.used).to be 0
+    expect(buffer.pointer).to be 0
   end
 
   it 'contains just referenced entry' do
     buffer = DbmsBuffers::GClockBuffer.new(2)
+    expect(buffer.pointer).to be 0
     buffer.access('a')
+    expect(buffer.pointer).to be 1
     expect(buffer.used).to be 1
     expect(buffer.contains?('a')).to be true
     expect(buffer.clock_value_of('a')).to be 1
@@ -17,8 +20,11 @@ RSpec.describe DbmsBuffers::GClockBuffer do
 
   it 'does not contain same entry twice' do
     buffer = DbmsBuffers::GClockBuffer.new(2)
+    expect(buffer.pointer).to be 0
     buffer.access('a')
+    expect(buffer.pointer).to be 1
     buffer.access('a')
+    expect(buffer.pointer).to be 1
     expect(buffer.used).to be 1
     expect(buffer.contains?('a')).to be true
     expect(buffer.clock_value_of('a')).to be 2
@@ -26,8 +32,11 @@ RSpec.describe DbmsBuffers::GClockBuffer do
 
   it 'can hold multiple entries' do
     buffer = DbmsBuffers::GClockBuffer.new(2)
+    expect(buffer.pointer).to be 0
     buffer.access('a')
+    expect(buffer.pointer).to be 1
     buffer.access('b')
+    expect(buffer.pointer).to be 0
     expect(buffer.used).to be 2
     expect(buffer.contains?('a')).to be true
     expect(buffer.clock_value_of('a')).to be 1
@@ -37,9 +46,13 @@ RSpec.describe DbmsBuffers::GClockBuffer do
 
   it 'gives multiple chances' do
     buffer = DbmsBuffers::GClockBuffer.new(2)
+    expect(buffer.pointer).to be 0
     buffer.access :a
+    expect(buffer.pointer).to be 1
     buffer.access :b
+    expect(buffer.pointer).to be 0
     buffer.access :c
+    expect(buffer.pointer).to be 1
 
     expect(buffer.contains?(:a) ^ buffer.contains?(:b)).to be true
 


### PR DESCRIPTION
After replacement the pointer was not moved.

E.g.:
|             | 0 | 1 |
|-------------|---|---|
| Content     | A | B |
| Ref Counter | 0 | 0 |
|Pointer         | X |   |

After access to C it should be

|             | 0 | 1 |
|-------------|---|---|
| Content     | C | B |
| Ref Counter | 1 | 0 |
|Pointer         |  | X  |

But was

|             | 0 | 1 |
|-------------|---|---|
| Content     | C | B |
| Ref Counter | 1 | 0 |
|Pointer         | X |   |

Added test cases to spec file to catch that mistake and fixed it